### PR TITLE
#73 Bug: 会话组件，Card 和两个修改 Button 点击范围冲突 

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -22,15 +22,11 @@ declare module '@vue/runtime-core' {
     ElMain: typeof import('element-plus/es')['ElMain']
     ElMenu: typeof import('element-plus/es')['ElMenu']
     ElMenuItem: typeof import('element-plus/es')['ElMenuItem']
-    ElMenuItemGroup: typeof import('element-plus/es')['ElMenuItemGroup']
     ElOption: typeof import('element-plus/es')['ElOption']
     ElPagination: typeof import('element-plus/es')['ElPagination']
-    ElRadioButton: typeof import('element-plus/es')['ElRadioButton']
-    ElRadioGroup: typeof import('element-plus/es')['ElRadioGroup']
     ElRow: typeof import('element-plus/es')['ElRow']
     ElSelect: typeof import('element-plus/es')['ElSelect']
     ElSkeleton: typeof import('element-plus/es')['ElSkeleton']
-    ElSubMenu: typeof import('element-plus/es')['ElSubMenu']
     ElTabPane: typeof import('element-plus/es')['ElTabPane']
     ElTabs: typeof import('element-plus/es')['ElTabs']
     ElText: typeof import('element-plus/es')['ElText']
@@ -41,8 +37,5 @@ declare module '@vue/runtime-core' {
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     SideBar: typeof import('./src/components/SideBar.vue')['default']
-  }
-  export interface ComponentCustomProperties {
-    vLoading: typeof import('element-plus/es')['ElLoadingDirective']
   }
 }

--- a/src/views/Chat/ChatView.vue
+++ b/src/views/Chat/ChatView.vue
@@ -216,7 +216,7 @@ const chatContentRandered = (s:string)=>{
 }
 
 async function sendmessage() {
-  if (model.value != "") {
+  if (apikey.value != "" && model.value != "") {
     if (queryId.value == "0" || queryId.value == "1" || queryId.value == "") {
       //如果是在初始页面时候聊天 或 如果是在删除后聊天
       const newmessage = {

--- a/src/views/Chat/ChatView.vue
+++ b/src/views/Chat/ChatView.vue
@@ -216,7 +216,7 @@ const chatContentRandered = (s:string)=>{
 }
 
 async function sendmessage() {
-  if (apikey.value != "" && model.value != "") {
+  if (model.value != "") {
     if (queryId.value == "0" || queryId.value == "1" || queryId.value == "") {
       //如果是在初始页面时候聊天 或 如果是在删除后聊天
       const newmessage = {

--- a/src/views/Chat/components/CreateNewChat.vue
+++ b/src/views/Chat/components/CreateNewChat.vue
@@ -1,7 +1,7 @@
 <template>
-  <el-card class="my-2 hover:cursor-pointer">
+  <el-card class="my-2 hover:cursor-pointer"  @click="handleChatSelect">
     <div class="flex flex-row items-center justify-center -my-2">
-      <div class="flex items-center" @click="handleChatSelect">
+      <div class="flex items-center">
         <el-icon size="20">
           <ChatLineSquare />
         </el-icon>
@@ -41,23 +41,28 @@ import { ref, defineProps } from "vue";
 import { useRouter } from "vue-router";
 import type { PropType } from "vue";
 import { ChatLineSquare, Edit, Delete } from "@element-plus/icons-vue";
+import { el } from "element-plus/es/locale";
 
 const router = useRouter();
 
 const input = ref("");
 const changeTitleDialogVisiable = ref(false);
 const deleteChatDialogVisiable = ref(false);
+const newId = ref();
 
 const emit = defineEmits<{
   (e: "deleteChat", chatId: string): void;
 }>();
 
 const handleChatSelect = () => {
+  newId.value = conversation.chatID;
   router.push({ name: "chat", params: { id: conversation.chatID } });
 };
 
 const opendialog = () => {
-  changeTitleDialogVisiable.value = true;
+  if(newId.value == conversation.chatID ){
+    changeTitleDialogVisiable.value = true;
+  }
 };
 
 const closedialog = () => {
@@ -69,7 +74,9 @@ const closedialog = () => {
 };
 
 const handleDeleteChat = () => {
-  deleteChatDialogVisiable.value = true;
+  if(newId.value == conversation.chatID ){
+    deleteChatDialogVisiable.value = true;
+  }
 };
 
 const deleteChat = () => {


### PR DESCRIPTION
Issues https://github.com/yacw-team/yacw-frontend/issues/73 Bug: 会话组件，Card 和两个修改 Button 点击范围冲突 

没有完全解决问题，点击组件的任意地方可以进行页面切换，第一次点击时，点击到编辑和删除按钮不会打开弹窗，点击过一次后，点击到编辑和删除按钮时会切换页面然后打开弹窗